### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,14 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:${VERSION_PHP=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
      - DOCUMENT_ROOT=/test/behat-transformation-context
 
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-ci:${VERSION_PHP=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -19,7 +19,7 @@ pipeline:
 
   composer-update-lowest:
     group: prepare-update
-    image: fpfis/httpd-php-ci:${VERSION_PHP=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -30,13 +30,13 @@ pipeline:
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-ci:${VERSION_PHP=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/grumphp run
 
   behat:
     group: test
-    image: fpfis/httpd-php-ci:${VERSION_PHP=7.1}
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/behat --strict
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ pipeline:
       - ./vendor/bin/behat --strict
 
 matrix:
-  VERSION_PHP:
+  PHP_VERSION:
     - 5.6
     - 7.1
     - 7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.